### PR TITLE
hitting enter with focus on the modal body will trigger the next/confirm...

### DIFF
--- a/src/confirmation_modal.js
+++ b/src/confirmation_modal.js
@@ -6,7 +6,8 @@
 BackboneBootstrapModals.ConfirmationModal = BackboneBootstrapModals.BaseModal.extend({
 
   confirmationEvents: {
-    'click #confirmation-confirm-btn': 'onClickConfirm'
+    'click #confirmation-confirm-btn': 'onClickConfirm',
+    'keypress .modal-body': 'onKeyPress'
   },
 
   // Default set of BaseModal options for use as ConfirmationModal
@@ -74,10 +75,21 @@ BackboneBootstrapModals.ConfirmationModal = BackboneBootstrapModals.BaseModal.ex
     return eventHashes.concat(this.confirmationEvents);
   },
 
+  onKeyPress: function(e) {
+    // if the user presses the enter key
+    if (e.which === 13) {
+      e.preventDefault();
+      this.$('#confirmation-confirm-btn').click();
+    }
+  },
+
   onClickConfirm: function(e) {
     e.preventDefault();
     e.currentTarget.disabled = true;
+    this.confirmProgress(e);
+  },
 
+  confirmProgress: function(e){
     // Execute the specified callback if it exists, then hide the modal.
     // The modal will not be hidden if the callback returns false.
     if (this.onConfirm) {

--- a/src/wizard_modal.js
+++ b/src/wizard_modal.js
@@ -7,7 +7,8 @@ BackboneBootstrapModals.WizardModal = BackboneBootstrapModals.BaseModal.extend({
 
   wizardEvents: {
     'click #confirmation-previous-btn': 'onClickPrevious',
-    'click #confirmation-next-btn': 'onClickNext'
+    'click #confirmation-next-btn': 'onClickNext',
+    'keypress .modal-body': 'onKeyPress'
   },
 
   getBodyView: function(options) {
@@ -94,10 +95,21 @@ BackboneBootstrapModals.WizardModal = BackboneBootstrapModals.BaseModal.extend({
     this.renderPreviousStep();
   },
 
+  onKeyPress: function(e) {
+    // if the user presses the enter key
+    if (e.which === 13) {
+      e.preventDefault();
+      this.$('#confirmation-next-btn').click();
+    }
+  },
+
   onClickNext: function(e) {
     e.preventDefault();
     e.currentTarget.disabled = true;
+    this.goForward(e);
+  },
 
+  goForward: function(e) {
     // Execute the specified callback if it exists, then proceed.
     // The modal will not proceed if the callback returns false.
     if (this.currentStep.onNext) {


### PR DESCRIPTION
... handler, as it should behave intuitively.
